### PR TITLE
Introduce a new multi-select cell type

### DIFF
--- a/Entities/InvestmentInterest.schema.json
+++ b/Entities/InvestmentInterest.schema.json
@@ -1,49 +1,64 @@
-  {
-    "name": "InvestmentInterest",
-    "type": "object",
-    "properties": {
-      "name": {
-        "type": "string",
-        "description": "Full name of interested investor"
-      },
-      "email": {
-        "type": "string",
-        "format": "email",
-        "description": "Email address"
-      },
-      "phone": {
-        "type": "string",
-        "description": "Phone number"
-      },
-      "investment_amount": {
-        "type": "string",
-        "enum": [
-          "under_100k",
-          "100k_500k",
-          "500k_1m",
-          "1m_5m",
-          "over_5m"
-        ],
-        "description": "Investment range interested in"
-      },
-      "investor_type": {
-        "type": "string",
-        "enum": [
-          "individual",
-          "institutional",
-          "family_office",
-          "vc_fund",
-          "other"
-        ],
-        "description": "Type of investor"
-      },
-      "message": {
-        "type": "string",
-        "description": "Additional message or questions"
-      }
+{
+  "name": "InvestmentInterest",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Full name of interested investor"
     },
-    "required": [
-      "name",
-      "email"
-    ]
-  }
+    "email": {
+      "type": "string",
+      "format": "email",
+      "description": "Email address"
+    },
+    "phone": {
+      "type": "string",
+      "description": "Phone number"
+    },
+    "investment_amount": {
+      "type": "string",
+      "enum": [
+        "under_100k",
+        "100k_500k",
+        "500k_1m",
+        "1m_5m",
+        "over_5m"
+      ],
+      "description": "Investment range interested in"
+    },
+    "investor_type": {
+      "type": "string",
+      "enum": [
+        "individual",
+        "institutional",
+        "family_office",
+        "vc_fund",
+        "other"
+      ],
+      "description": "Type of investor"
+    },
+    "message": {
+      "type": "string",
+      "description": "Additional message or questions"
+    },
+    "preferred_commodities": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "gold",
+          "cocoa",
+          "coffee",
+          "cashew",
+          "cotton",
+          "sesame"
+        ]
+      },
+      "description": "Commodities the investor is most interested in"
+    }
+  },
+  "required": [
+    "name",
+    "email"
+  ]
+}

--- a/Pages/Invest.jsx
+++ b/Pages/Invest.jsx
@@ -6,6 +6,7 @@ import { Textarea } from "../components/ui/textarea";
 import { Label } from "../components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "../components/ui/card";
 import { Alert, AlertDescription } from "../components/ui/alert";
+import { MultiSelectCell } from "../components/ui/multi-select-cell";
 import { 
   TrendingUp, 
   DollarSign, 
@@ -25,7 +26,8 @@ export default function Invest() {
     phone: "",
     investment_amount: "",
     investor_type: "",
-    message: ""
+    message: "",
+    preferred_commodities: []
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitSuccess, setSubmitSuccess] = useState(false);
@@ -50,7 +52,8 @@ export default function Invest() {
         phone: "",
         investment_amount: "",
         investor_type: "",
-        message: ""
+        message: "",
+        preferred_commodities: []
       });
     } catch (error) {
       setSubmitError("There was an error submitting your information. Please try again.");
@@ -79,6 +82,16 @@ export default function Invest() {
       title: "Risk Mitigation",
       description: "Diversified approach across multiple commodities and stable jurisdictions"
     }
+  ];
+
+
+  const commodityOptions = [
+    { value: "gold", label: "Gold" },
+    { value: "cocoa", label: "Cocoa" },
+    { value: "coffee", label: "Coffee" },
+    { value: "cashew", label: "Cashew" },
+    { value: "cotton", label: "Cotton" },
+    { value: "sesame", label: "Sesame" }
   ];
 
   const projectedReturns = [
@@ -252,6 +265,16 @@ export default function Invest() {
                         <option value="other">Other</option>
                       </select>
                     </div>
+                  </div>
+
+                  <div>
+                    <Label htmlFor="preferred_commodities" className="font-semibold">Preferred Commodities</Label>
+                    <MultiSelectCell
+                      id="preferred_commodities"
+                      options={commodityOptions}
+                      value={formData.preferred_commodities}
+                      onChange={(values) => handleInputChange("preferred_commodities", values)}
+                    />
                   </div>
 
                   <div>

--- a/components/ui/multi-select-cell.jsx
+++ b/components/ui/multi-select-cell.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+export function MultiSelectCell({
+  id,
+  options,
+  value = [],
+  onChange,
+  className = "",
+}) {
+  const selectedValues = Array.isArray(value) ? value : [];
+
+  const toggleValue = (optionValue) => {
+    if (selectedValues.includes(optionValue)) {
+      onChange(selectedValues.filter((item) => item !== optionValue));
+      return;
+    }
+
+    onChange([...selectedValues, optionValue]);
+  };
+
+  return (
+    <div
+      id={id}
+      role="group"
+      aria-label="Multi-select"
+      className={`mt-2 grid grid-cols-2 gap-2 rounded-xl border border-slate-200 bg-white p-2 shadow-sm ${className}`}
+    >
+      {options.map((option) => {
+        const isSelected = selectedValues.includes(option.value);
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => toggleValue(option.value)}
+            aria-pressed={isSelected}
+            className={`rounded-lg border px-3 py-2 text-left text-sm transition-colors ${
+              isSelected
+                ? "border-[var(--sonder-teal)] bg-teal-50 text-[var(--sonder-dark-text)]"
+                : "border-slate-200 bg-white text-slate-600 hover:border-[var(--sonder-teal)]"
+            }`}
+          >
+            {option.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable multi-select input so users can choose multiple preferred commodities in the investment interest form and reuse the control elsewhere in the UI.

### Description
- Add a new component `components/ui/multi-select-cell.jsx` that supports toggle-on/toggle-off selection, selected-state styling, and basic accessibility with `role="group"` and `aria-pressed` on options.
- Integrate the component into the investment form in `Pages/Invest.jsx` by importing `MultiSelectCell`, adding `preferred_commodities` to the form state and reset logic, and wiring a `commodityOptions` list to the control.
- Extend the API/schema contract in `Entities/InvestmentInterest.schema.json` with a `preferred_commodities` property typed as an array of string enum values (`gold`, `cocoa`, `coffee`, `cashew`, `cotton`, `sesame`).

### Testing
- Ran `git diff --check` to validate whitespace/format issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07d2468ce08333a17227d9bc893e8e)